### PR TITLE
Make it usable without an X server (e.g. over plain ssh).

### DIFF
--- a/code/analyze.py
+++ b/code/analyze.py
@@ -20,10 +20,12 @@ import io_mp
 import math
 import numpy as np
 
-# Module for handling display
-import matplotlib.pyplot as plt
 # The root plotting module, to change options like font sizes, etc...
 import matplotlib
+# The following line suppresses the need for an X server
+matplotlib.use("Agg")
+# Module for handling display
+import matplotlib.pyplot as plt
 
 # Module to handle warnings from matplotlib
 import warnings


### PR DESCRIPTION
Hi Benjamin,

I added a trivial patch that tells matplotlib to use a limited backend. Basically, everything should work the same, but now you don't need an X server to run analyze.py. I made a couple of tests and it should work.
