### PR TITLE
README: code in "montepython" not "code"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ You can add the following line to your .bashrc file:
 
 .. code::
 
-    export PATH=/path/to/MontePython/montepython/$PATH
+    export PATH=/path/to/MontePython/montepython/:$PATH
 
 to be able to call the program from anywhere.
 


### PR DESCRIPTION
It took me a while to figure out that the "code" directory is in the repository "montepython". I've substituted all the occurrences of "code/" with "montepython/". I've also fixed some typo. 
