### PR TITLE
Dict comprehension fix

### DIFF
--- a/montepython/parser_mp.py
+++ b/montepython/parser_mp.py
@@ -162,7 +162,7 @@ def parse_docstring(docstring, key_symbol="<**>", description_symbol="<++>"):
         msg += " as there are surrounded by '{1}"
         raise ValueError(msg.format(key_symbol, description_symbol))
 
-    helpdict = {k: v for k, v in zip(keys, descriptions)}
+    helpdict = dict(zip(keys, descriptions))
     return helpdict
 
 


### PR DESCRIPTION
works on python 2.6, 2.7 and 3.3. I guess it works on python3.x. 
And the code is also nicer now.

I haven't checked on 2.5 or smaller, but I hope they could be considered obsolete versions. 
