### PR TITLE
Update likelihood_class.py and sdss_lrgDR4.data

### DIFF
--- a/montepython/likelihoods/sdss_lrgDR4/sdss_lrgDR4.data
+++ b/montepython/likelihoods/sdss_lrgDR4/sdss_lrgDR4.data
@@ -22,8 +22,8 @@ sdss_lrgDR4.Ag          = 1.4
 # parameter for the rescaling with respect to a fiducial model
 sdss_lrgDR4.use_scaling         = True
 sdss_lrgDR4.redshift            = 0.35
-sdss_lrgDR4.d_angular_fid       = 722.4134
-sdss_lrgDR4.d_radial_fid        = 897.9993
+sdss_lrgDR4.d_angular_fid       = 1032.0543
+sdss_lrgDR4.d_radial_fid        = 3665.5692
 
 sdss_lrgDR4.min_mpk_kbands_use = 1
 sdss_lrgDR4.max_mpk_kbands_use = 65


### PR DESCRIPTION
Instead of the pull-request I've sent before, now I'm sending one that also includes a fix in the .data file for montepython/likelihoods/sdss_lrgDR4

This fix replaces the fiducial values for the angular diameter distance and the radial distance computed for the fiducial cosmology of sdss_lrgDR4. The angular diameter distance in that file was computed in units of Mpc/h whereas the code compares it with cosmo.angular_distance which is in units of Mpc. The radial distance was computed as z/H(z) in units of Mpc/h whereas the code compares it with the value returned from cosmo.z_of_r which is 1/H(z) in units of Mpc.

Below I copy the comments on the changes I made in likelihood_class.py

This is a fix for the scaling factor defined in the power spectrum likelihood (Likelihood_mpk).

The scaling factor was defined at line 1364 of the file montepython/likelihood_class.py and then it is applied to the theory power spectrum in order to compare it with the observed power spectrum, which is computed with a different cosmology.

The scaling computed at that line was actually the inverse of what it should be applied, i.e. it should be scaling=Dv_fiducial/Dv (and not Dv/Dv_fiducial).

Hope this fix is clear enough and it does not require more explanation than the ones already provided at the comments next to the changed lines.
