### PR TITLE
Fix a bug if using priors

### DIFF
--- a/montepython/data.py
+++ b/montepython/data.py
@@ -996,7 +996,7 @@ class Parameter(dict):
 
         self['initial'] = array[0:4]
         self['scale'] = array[4]
-        self['role'] = array[-1]
+        self['role'] = array[5]
         self['tex_name'] = io_mp.get_tex_name(key)
         if array[3] == 0:
             self['status'] = 'fixed'


### PR DESCRIPTION
Hi, this should fix a bug when using priors - if I read the code for parsing configuration files correctly I am supposed to use a gaussian prior like this:
`data.parameters['someparameter'] = [ 60, None,  None, 5, 1, 'cosmo', 'gaussian', 60, 5] `
However this fails as the parameter type currently is read from the last entry of the above array. The following works but seems overly verbose:
`data.parameters['someparameter'] = [ 60, None,  None, 5, 1, 'cosmo', 'gaussian', 60, 5, 'cosmo'] `. 
Please let me know in case this is intended behavior for some reason.